### PR TITLE
Add note about bug QTBUG-132337

### DIFF
--- a/01_gettings_started/07_window_hide_min_max.py
+++ b/01_gettings_started/07_window_hide_min_max.py
@@ -60,6 +60,10 @@ def main():
 
     # Remove minimize maximize button works on Windows 10 / Ubuntu X11, not
     # Ubuntu Wayland: https://bugreports.qt.io/browse/QTBUG-110448
+
+    # Another Pyside6 bug reported when removing the min/max button also removes
+    # the close button on Windows 11:
+    # https://bugreports.qt.io/browse/QTBUG-132337
     window.setWindowFlags(window.windowFlags() & Qt.CustomizeWindowHint)
     window.setWindowFlags(window.windowFlags() & ~Qt.WindowMinMaxButtonsHint)
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ examples in this repository:
   `showNormal()` not working when window is minimized on Ubuntu X11 and Wayland.
 - [QTBUG-110448](https://bugreports.qt.io/browse/QTBUG-110448): Cannot remove 
   window min/max buttons on Ubuntu Wayland.
+- [QTBUG-132337](https://bugreports.qt.io/browse/QTBUG-132337): Removing window 
+  min/max buttons on Windows 11 also removes close button
 - [QTCREATORBUG-25807](https://bugreports.qt.io/browse/QTCREATORBUG-25807):
   PySide6 generated class doesn't load UI file correctly with QtCreator.
 - Example `13_qt_creator\01_qt_creator_qwidget.py` generates a warning:


### PR DESCRIPTION
Cannot remove min/max window buttons as it also removes close button. Reproducible on at least Windows 11.

Issue #7 